### PR TITLE
[Feat#1] JPA 기반 DB 및 프로젝트 아키텍쳐 구성

### DIFF
--- a/src/main/java/com/ironknee/Knee2KneelSpring/controller/game/GameController.java
+++ b/src/main/java/com/ironknee/Knee2KneelSpring/controller/game/GameController.java
@@ -1,0 +1,7 @@
+package com.ironknee.Knee2KneelSpring.controller.game;
+
+import org.springframework.stereotype.Controller;
+
+@Controller
+public class GameController {
+}

--- a/src/main/java/com/ironknee/Knee2KneelSpring/controller/stage/StageController.java
+++ b/src/main/java/com/ironknee/Knee2KneelSpring/controller/stage/StageController.java
@@ -1,0 +1,7 @@
+package com.ironknee.Knee2KneelSpring.controller.stage;
+
+import org.springframework.stereotype.Controller;
+
+@Controller
+public class StageController {
+}

--- a/src/main/java/com/ironknee/Knee2KneelSpring/controller/statistics/StatisticsController.java
+++ b/src/main/java/com/ironknee/Knee2KneelSpring/controller/statistics/StatisticsController.java
@@ -1,0 +1,7 @@
+package com.ironknee.Knee2KneelSpring.controller.statistics;
+
+import org.springframework.stereotype.Controller;
+
+@Controller
+public class StatisticsController {
+}

--- a/src/main/java/com/ironknee/Knee2KneelSpring/controller/user/UserController.java
+++ b/src/main/java/com/ironknee/Knee2KneelSpring/controller/user/UserController.java
@@ -1,0 +1,7 @@
+package com.ironknee.Knee2KneelSpring.controller.user;
+
+import org.springframework.stereotype.Controller;
+
+@Controller
+public class UserController {
+}

--- a/src/main/java/com/ironknee/Knee2KneelSpring/entity/GameEntity.java
+++ b/src/main/java/com/ironknee/Knee2KneelSpring/entity/GameEntity.java
@@ -1,0 +1,44 @@
+package com.ironknee.Knee2KneelSpring.entity;
+
+import com.ironknee.Knee2KneelSpring.service.game.GameMode;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "game")
+public class GameEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long gameId;
+
+    @Column(nullable = false)
+    private LocalDateTime duration;
+
+    @Column(nullable = false)
+    private Long maxStudent;
+
+    @Column(nullable = false)
+    private Long maxAssistant;
+
+    @Column(nullable = false)
+    private Long maxCom;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private GameMode mode;
+
+    @ManyToOne
+    @JoinColumn(name = "stageId", nullable = false)
+    private StageEntity stage;
+
+    @Column(nullable = true)
+    @OneToMany(mappedBy = "game", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<PlayerEntity> playerEntityList;
+}

--- a/src/main/java/com/ironknee/Knee2KneelSpring/entity/PlayerEntity.java
+++ b/src/main/java/com/ironknee/Knee2KneelSpring/entity/PlayerEntity.java
@@ -1,0 +1,36 @@
+package com.ironknee.Knee2KneelSpring.entity;
+
+import com.ironknee.Knee2KneelSpring.service.player.PlayerRole;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "player")
+public class PlayerEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long playerId;
+
+    @Column(nullable = false)
+    private PlayerRole role;
+
+
+    @OneToOne
+    @JoinColumn(name = "userId", nullable = false)
+    private UserEntity user;
+
+    @ManyToOne
+    @JoinColumn(name = "gameId", nullable = false)
+    private GameEntity game;
+
+//    @Column(nullable = true)
+//    private List<SkillEntity> skillEntityList;
+//
+//    @Column(nullable = true)
+//    private List<ItemEntity> itemEntityList;
+
+}

--- a/src/main/java/com/ironknee/Knee2KneelSpring/entity/StageEntity.java
+++ b/src/main/java/com/ironknee/Knee2KneelSpring/entity/StageEntity.java
@@ -1,0 +1,37 @@
+package com.ironknee.Knee2KneelSpring.entity;
+
+import com.ironknee.Knee2KneelSpring.service.stage.StageDepartment;
+import com.ironknee.Knee2KneelSpring.service.stage.StageDifficulty;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.List;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "stage")
+public class StageEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long stageId;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private StageDepartment department;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private StageDifficulty difficulty;
+
+//    @Column(nullable = true)
+//    private String assignment;
+
+//    @Column(nullable = true)
+//    private List<Mission> missionList;
+
+    @OneToMany(mappedBy = "stage", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<GameEntity> gameEntityList;
+}

--- a/src/main/java/com/ironknee/Knee2KneelSpring/entity/StatisticsEntity.java
+++ b/src/main/java/com/ironknee/Knee2KneelSpring/entity/StatisticsEntity.java
@@ -1,0 +1,72 @@
+package com.ironknee.Knee2KneelSpring.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "statistics")
+public class StatisticsEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long statisticsId;
+
+    @Column(nullable = false)
+    private Long roundTotal = 0L;
+
+    @Column(nullable = false)
+    private Long winTotal = 0L;
+
+    @Column(nullable = false)
+    private Long loseTotal = 0L;
+
+    @Column(nullable = false)
+    private Long winRateTotal = 0L;
+
+    @Column(nullable = false)
+    private Long roundStudent = 0L;
+
+    @Column(nullable = false)
+    private Long winStudent = 0L;
+
+    @Column(nullable = false)
+    private Long loseStudent = 0L;
+
+    @Column(nullable = false)
+    private Long winRateStudent = 0L;
+
+    @Column(nullable = false)
+    private Long roundProfessor = 0L;
+
+    @Column(nullable = false)
+    private Long winProfessor = 0L;
+
+    @Column(nullable = false)
+    private Long loseProfessor = 0L;
+
+    @Column(nullable = false)
+    private Long winRateProfessor = 0L;
+
+    @Column(nullable = false)
+    private Long roundAssistant = 0L;
+
+    @Column(nullable = false)
+    private Long winAssistant = 0L;
+
+    @Column(nullable = false)
+    private Long loseAssistant = 0L;
+
+    @Column(nullable = false)
+    private Long winRateAssistant = 0L;
+
+
+    @OneToOne
+    @JoinColumn(name = "userId", nullable = false)
+    private UserEntity user;
+}

--- a/src/main/java/com/ironknee/Knee2KneelSpring/entity/UserEntity.java
+++ b/src/main/java/com/ironknee/Knee2KneelSpring/entity/UserEntity.java
@@ -1,0 +1,54 @@
+package com.ironknee.Knee2KneelSpring.entity;
+
+import com.ironknee.Knee2KneelSpring.service.user.MatchStatus;
+import com.ironknee.Knee2KneelSpring.service.user.UserRank;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.UUID;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "user")
+public class UserEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID userId;
+
+    @Column(nullable = false, unique = true)
+    private String nickname;
+
+    @Column(nullable = false, unique = true)
+    private String password;
+
+    @Column(nullable = false, unique = true)
+    private String email;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private MatchStatus matchStatus = MatchStatus.none;
+
+    @Column(nullable = false)
+    private Long exp = 0L;
+
+    @Column(nullable = false)
+    private Long level = 0L;
+
+    @Column(nullable = false)
+    private Long rankPoint = 0L;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private UserRank userRank = UserRank.unranked;
+
+
+    @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private PlayerEntity player;
+
+    @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private StatisticsEntity statistics;
+}

--- a/src/main/java/com/ironknee/Knee2KneelSpring/service/game/GameMode.java
+++ b/src/main/java/com/ironknee/Knee2KneelSpring/service/game/GameMode.java
@@ -1,0 +1,5 @@
+package com.ironknee.Knee2KneelSpring.service.game;
+
+public enum GameMode {
+    single, multi
+}

--- a/src/main/java/com/ironknee/Knee2KneelSpring/service/player/PlayerRole.java
+++ b/src/main/java/com/ironknee/Knee2KneelSpring/service/player/PlayerRole.java
@@ -1,0 +1,5 @@
+package com.ironknee.Knee2KneelSpring.service.player;
+
+public enum PlayerRole {
+    professor, assistant, student
+}

--- a/src/main/java/com/ironknee/Knee2KneelSpring/service/stage/StageDepartment.java
+++ b/src/main/java/com/ironknee/Knee2KneelSpring/service/stage/StageDepartment.java
@@ -1,0 +1,5 @@
+package com.ironknee.Knee2KneelSpring.service.stage;
+
+public enum StageDepartment {
+    computer_science, korean_literature, english_literature
+}

--- a/src/main/java/com/ironknee/Knee2KneelSpring/service/stage/StageDifficulty.java
+++ b/src/main/java/com/ironknee/Knee2KneelSpring/service/stage/StageDifficulty.java
@@ -1,0 +1,5 @@
+package com.ironknee.Knee2KneelSpring.service.stage;
+
+public enum StageDifficulty {
+    computer_science, korean_literature, english_literature
+}

--- a/src/main/java/com/ironknee/Knee2KneelSpring/service/user/MatchStatus.java
+++ b/src/main/java/com/ironknee/Knee2KneelSpring/service/user/MatchStatus.java
@@ -1,0 +1,5 @@
+package com.ironknee.Knee2KneelSpring.service.user;
+
+public enum MatchStatus {
+    none, matched, playing
+}

--- a/src/main/java/com/ironknee/Knee2KneelSpring/service/user/UserRank.java
+++ b/src/main/java/com/ironknee/Knee2KneelSpring/service/user/UserRank.java
@@ -1,0 +1,5 @@
+package com.ironknee.Knee2KneelSpring.service.user;
+
+public enum UserRank {
+    unranked, bronze, silver, gold, platinum
+}


### PR DESCRIPTION
## 💬리뷰 참고사항
- DB 스키마 변경
  - User 테이블 isMatched, isPlaying 속성 match_status 속성으로 병합
     (match_status : none, matched, playing 의 3개 값으로 구성된 enum)
  - Statistics, Player 테이블 id 속성 추가
  - Stage : Game 연관 관계 1:1 -> 1:N 으로 변경
 
- Enum 객체로 생성된 객체 : GameMode, PlayerRole, StageDepartment, StageDifficulty, MatchStatus, UserRank
- Player 테이블 내 skill과 item은 중간 이후에 새로 추가 예정
- Stage 테이블 내 assignment와 mission의 경우 클라이언트와 구현 방식 논의 후 추가 예정

## #️⃣연관된 이슈
close #1 
